### PR TITLE
fix(api): patch and create owner dto not extending base owner dto

### DIFF
--- a/api/v1/apimodel.go
+++ b/api/v1/apimodel.go
@@ -25,6 +25,8 @@ type OwnerCreateDto struct {
 	Contact string `json:"contact"`
 	// The product owner of this owner space
 	ProductOwner *string `json:"productOwner,omitempty"`
+	// A list of users that are allowed to promote services in this owner space
+	Promoters []string `json:"promoters,omitempty"`
 	// The default jira project that is used by this owner space
 	DefaultJiraProject *string `json:"defaultJiraProject,omitempty"`
 	// The jira issue to use for committing a change, or the last jira issue used.
@@ -59,6 +61,8 @@ type OwnerPatchDto struct {
 	Contact *string `json:"contact,omitempty"`
 	// The product owner of this owner space
 	ProductOwner *string `json:"productOwner,omitempty"`
+	// A list of users that are allowed to promote services in this owner space
+	Promoters []string `json:"promoters,omitempty"`
 	// The default jira project that is used by this owner space
 	DefaultJiraProject *string `json:"defaultJiraProject,omitempty"`
 	// ISO-8601 UTC date time at which this information was originally committed. When sending an update, include the original timestamp you got so we can detect concurrent updates.

--- a/docs/openapi-v3-spec.json
+++ b/docs/openapi-v3-spec.json
@@ -1957,6 +1957,19 @@
             "description": "The product owner of this owner space",
             "example": "kschlangenheld"
           },
+          "promoters": {
+            "type": "array",
+            "description": "A list of users that are allowed to promote services in this owner space",
+            "items": {
+              "type": "string",
+              "description": "The username of a user allowed to promote services in this owner space",
+              "example": "kschlangenheld"
+            },
+            "example": [
+              "kschlangenheld",
+              "someotheruser"
+            ]
+          },
           "defaultJiraProject": {
             "type": "string",
             "description": "The default jira project that is used by this owner space",
@@ -1986,6 +1999,19 @@
             "type": "string",
             "description": "The product owner of this owner space",
             "example": "kschlangenheld"
+          },
+          "promoters": {
+            "type": "array",
+            "description": "A list of users that are allowed to promote services in this owner space",
+            "items": {
+              "type": "string",
+              "description": "The username of a user allowed to promote services in this owner space",
+              "example": "kschlangenheld"
+            },
+            "example": [
+              "kschlangenheld",
+              "someotheruser"
+            ]
           },
           "defaultJiraProject": {
             "type": "string",


### PR DESCRIPTION
Adds missing properties to `OwnerPatchDto` and `OwnerCreateDto`

Fixes RELTEC-10000

# Checklist

- [x] I have read the [CONTRIBUTING.md](/CONTRIBUTING-template.md)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no lint errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] Only MIT licensed or MIT license compatible dependencies are used (e.g.: Apache2 or BSD)
- [x] The code contains no credentials, personalized data or company secrets