### PR TITLE
fix(ci): security scan unable to access snyk token

### DIFF
--- a/.github/workflows/snyk.yaml
+++ b/.github/workflows/snyk.yaml
@@ -1,10 +1,6 @@
 name: 🔐 Security Scan
 on:
   push:
-    branches: [ main ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ main ]
   schedule:
     - cron: '40 20 * * 0'
 jobs:


### PR DESCRIPTION
Remove the `pull_request` trigger as it prevents access to the `SNYK_TOKEN`. See here for more details: https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow

Fixes RELTEC-10172