### PR TITLE
fix(vault): Add missing default for vault kubernetes-auth token path

### DIFF
--- a/internal/repository/vault/config.go
+++ b/internal/repository/vault/config.go
@@ -36,7 +36,7 @@ var ConfigItems = []auconfigapi.ConfigItem{
 	{
 		Key:         config.KeyVaultAuthKubernetesTokenPath,
 		EnvName:     config.KeyVaultAuthKubernetesTokenPath,
-		Default:     "",
+		Default:     "/var/run/secrets/kubernetes.io/serviceaccount/token",
 		Description: "file path to the service-account token",
 		Validate:    auconfigapi.ConfigNeedsNoValidation,
 	},


### PR DESCRIPTION
# Description

Adds missing default value

# Checklist

- [x] I have read the [CONTRIBUTING.md](/CONTRIBUTING-template.md)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no lint errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] Only MIT licensed or MIT license compatible dependencies are used (e.g.: Apache2 or BSD)
- [x] The code contains no credentials, personalized data or company secrets