### PR TITLE
Reltec 10917 multi service repos

### DIFF
--- a/acorns/service/repositoriesint.go
+++ b/acorns/service/repositoriesint.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	openapi "github.com/Interhyp/metadata-service/api/v1"
+	"github.com/StephanHCB/go-backend-service-common/api/apierrors"
 )
 
 const RepositoriesAcornName = "repositories"
@@ -10,6 +11,9 @@ const RepositoriesAcornName = "repositories"
 // Repositories provides the business logic for repository metadata.
 type Repositories interface {
 	IsRepositories() bool
+
+	// ValidRepositoryKey checks validity of a repository key and returns an error describing the problem if invalid
+	ValidRepositoryKey(ctx context.Context, repoKey string) apierrors.AnnotatedError
 
 	GetRepositories(ctx context.Context,
 		ownerAliasFilter string, serviceNameFilter string,

--- a/internal/service/repositories/acorn.go
+++ b/internal/service/repositories/acorn.go
@@ -2,6 +2,7 @@ package repositories
 
 import (
 	"context"
+	"github.com/Interhyp/metadata-service/acorns/config"
 	"github.com/Interhyp/metadata-service/acorns/service"
 	"github.com/StephanHCB/go-autumn-acorn-registry/api"
 	auzerolog "github.com/StephanHCB/go-autumn-logging-zerolog"
@@ -28,6 +29,8 @@ func (s *Impl) AssembleAcorn(registry auacornapi.AcornRegistry) error {
 	s.Cache = registry.GetAcornByName(service.CacheAcornName).(service.Cache)
 	s.Updater = registry.GetAcornByName(service.UpdaterAcornName).(service.Updater)
 	s.Owners = registry.GetAcornByName(service.OwnersAcornName).(service.Owners)
+
+	s.CustomConfiguration = config.Custom(s.Configuration)
 
 	s.Timestamp = registry.GetAcornByName(librepo.TimestampAcornName).(librepo.Timestamp)
 

--- a/internal/service/services/acorn.go
+++ b/internal/service/services/acorn.go
@@ -29,6 +29,7 @@ func (s *Impl) AssembleAcorn(registry auacornapi.AcornRegistry) error {
 	s.Cache = registry.GetAcornByName(service.CacheAcornName).(service.Cache)
 	s.Updater = registry.GetAcornByName(service.UpdaterAcornName).(service.Updater)
 	s.Owner = registry.GetAcornByName(service.OwnersAcornName).(service.Owners)
+	s.Repositories = registry.GetAcornByName(service.RepositoriesAcornName).(service.Repositories)
 
 	s.CustomConfiguration = config.Custom(s.Configuration)
 
@@ -51,6 +52,14 @@ func (s *Impl) SetupAcorn(registry auacornapi.AcornRegistry) error {
 		return err
 	}
 	err = registry.SetupAfter(s.Updater.(auacornapi.Acorn))
+	if err != nil {
+		return err
+	}
+	err = registry.SetupAfter(s.Owner.(auacornapi.Acorn))
+	if err != nil {
+		return err
+	}
+	err = registry.SetupAfter(s.Repositories.(auacornapi.Acorn))
 	if err != nil {
 		return err
 	}

--- a/test/acceptance/bitbucketmock/bitbucketmock.go
+++ b/test/acceptance/bitbucketmock/bitbucketmock.go
@@ -3,6 +3,7 @@ package bitbucketmock
 import (
 	"context"
 	"github.com/Interhyp/metadata-service/acorns/repository"
+	auacornapi "github.com/StephanHCB/go-autumn-acorn-registry/api"
 	"github.com/pkg/errors"
 )
 
@@ -11,32 +12,66 @@ const FILTER_FAILED_USERNAME = "filterfailedusername"
 type BitbucketMock struct {
 }
 
-func (b BitbucketMock) IsBitbucket() bool {
+func New() auacornapi.Acorn {
+	return &BitbucketMock{}
+}
+
+// implement acorn
+
+func (b *BitbucketMock) AcornName() string {
+	return repository.BitbucketAcornName
+}
+
+func (b *BitbucketMock) AssembleAcorn(registry auacornapi.AcornRegistry) error {
+	return nil
+}
+
+func (b *BitbucketMock) SetupAcorn(registry auacornapi.AcornRegistry) error {
+	return nil
+}
+
+func (b *BitbucketMock) TeardownAcorn(registry auacornapi.AcornRegistry) error {
+	return nil
+}
+
+// implement bitbucket interface
+
+func (b *BitbucketMock) IsBitbucket() bool {
 	return true
 }
 
-func (b BitbucketMock) Setup(ctx context.Context) error {
-	panic("implement me")
+func (b *BitbucketMock) Setup(ctx context.Context) error {
+	return nil
 }
 
-func (b BitbucketMock) GetBitbucketUser(ctx context.Context, username string) (repository.BitbucketUser, error) {
-	panic("implement me")
-}
-
-func (b BitbucketMock) GetBitbucketUsers(ctx context.Context, usernames []string) ([]repository.BitbucketUser, error) {
-	return []repository.BitbucketUser{
-		{
-			Name: "reviewer-one",
-		},
-		{
-			Name: "reviewer-two",
-		},
+func (b *BitbucketMock) GetBitbucketUser(ctx context.Context, username string) (repository.BitbucketUser, error) {
+	return repository.BitbucketUser{
+		Name: username,
 	}, nil
 }
 
-func (b BitbucketMock) FilterExistingUsernames(ctx context.Context, usernames []string) ([]string, error) {
+func (b *BitbucketMock) GetBitbucketUsers(ctx context.Context, usernames []string) ([]repository.BitbucketUser, error) {
+	result := []repository.BitbucketUser{}
+	for _, username := range usernames {
+		result = append(result, repository.BitbucketUser{
+			Name: username,
+		})
+	}
+	return result, nil
+	//return []repository.BitbucketUser{
+	//	{
+	//		Name: "reviewer-one",
+	//	},
+	//	{
+	//		Name: "reviewer-two",
+	//	},
+	//}, nil
+}
+
+func (b *BitbucketMock) FilterExistingUsernames(ctx context.Context, usernames []string) ([]string, error) {
 	if usernames[0] == FILTER_FAILED_USERNAME {
 		return []string{}, errors.New("error")
 	}
-	return []string{"approver-one", "approver-two"}, nil
+	return usernames, nil
+	// return []string{"approver-one", "approver-two"}, nil
 }

--- a/test/acceptance/servicectl_acc_test.go
+++ b/test/acceptance/servicectl_acc_test.go
@@ -2,6 +2,7 @@ package acceptance
 
 import (
 	"encoding/json"
+	openapi "github.com/Interhyp/metadata-service/api/v1"
 	"github.com/Interhyp/metadata-service/docs"
 	"github.com/stretchr/testify/require"
 	"net/http"
@@ -614,6 +615,57 @@ func TestPUTService_ChangeOwner(t *testing.T) {
 	require.Equal(t, tstServiceMovedExpectedKafka("some-service-backend"), string(actual))
 }
 
+func TestPUTService_ImplementationCrossrefAllowed(t *testing.T) {
+	tstReset()
+
+	docs.Given("Given an authenticated admin user")
+	token := tstValidAdminToken()
+
+	docs.Given("Given existing repositories crossref.helm-deployment and not-crossref.implementation")
+	deplRepoBody := tstRepository()
+	deplRepoResponse, err := tstPerformPost("/rest/api/v1/repositories/crossref.helm-deployment", token, &deplRepoBody)
+	require.Nil(t, err)
+	require.Equal(t, http.StatusCreated, deplRepoResponse.status)
+
+	implRepoBody := tstRepository()
+	implRepoResponse, err := tstPerformPost("/rest/api/v1/repositories/not-crossref.implementation", token, &implRepoBody)
+	require.Nil(t, err)
+	require.Equal(t, http.StatusCreated, implRepoResponse.status)
+
+	docs.Given("Given an existing service that references only the helm-deployment repository")
+	createBody := tstService("crossref")
+	createBody.Repositories = []string{
+		"crossref.helm-deployment",
+	}
+	createResponse, err := tstPerformPost("/rest/api/v1/services/crossref", token, &createBody)
+	require.Nil(t, err)
+	require.Equal(t, http.StatusCreated, createResponse.status)
+	// need commit hash from response, so we can perform valid update
+	var tmp openapi.ServiceDto
+	err = json.Unmarshal([]byte(createResponse.body), &tmp)
+	require.Nil(t, err)
+
+	docs.When("When they perform an update of the service, adding a cross-referenced implementation repository")
+	body := tstService("crossref")
+	body.Repositories = []string{
+		"crossref.helm-deployment",
+		"not-crossref.implementation",
+	}
+	body.CommitHash = tmp.CommitHash
+	response, err := tstPerformPut("/rest/api/v1/services/crossref", token, &body)
+
+	docs.Then("Then the request is successful")
+	require.Nil(t, err)
+	require.Equal(t, http.StatusOK, response.status)
+
+	docs.Then("And the service has been correctly written, committed and pushed")
+	filename := "owners/some-owner/services/crossref.yaml"
+	expectedYaml := strings.ReplaceAll(tstServiceExpectedYaml("crossref"), "crossref/implementation", "not-crossref/implementation")
+	require.Equal(t, expectedYaml, metadataImpl.ReadContents(filename))
+	require.True(t, metadataImpl.FilesCommitted[filename])
+	require.True(t, metadataImpl.Pushed)
+}
+
 // patch service
 
 func TestPATCHService_Success(t *testing.T) {
@@ -882,8 +934,8 @@ func TestPATCHService_ChangeOwner(t *testing.T) {
 	filename1 := "owners/deleteme/services/some-service-backend.yaml"
 	filename2old := "owners/some-owner/repositories/some-service-backend.helm-deployment.yaml"
 	filename2 := "owners/deleteme/repositories/some-service-backend.helm-deployment.yaml"
-	filename3old := "owners/some-owner/repositories/some-service-backend.helm-deployment.yaml"
-	filename3 := "owners/deleteme/repositories/some-service-backend.helm-deployment.yaml"
+	filename3old := "owners/some-owner/repositories/some-service-backend.implementation.yaml"
+	filename3 := "owners/deleteme/repositories/some-service-backend.implementation.yaml"
 	require.Equal(t, tstServiceExpectedYaml("some-service-backend"), metadataImpl.ReadContents(filename1))
 	require.True(t, metadataImpl.FilesCommitted[filename1])
 	require.True(t, metadataImpl.FilesCommitted[filename1old])
@@ -901,6 +953,135 @@ func TestPATCHService_ChangeOwner(t *testing.T) {
 	require.Equal(t, 1, len(kafkaImpl.Recording))
 	actual, _ := json.Marshal(kafkaImpl.Recording[0])
 	require.Equal(t, tstServiceMovedExpectedKafka("some-service-backend"), string(actual))
+}
+
+func TestPATCHService_ImplementationCrossrefAllowed(t *testing.T) {
+	tstReset()
+
+	docs.Given("Given an authenticated admin user")
+	token := tstValidAdminToken()
+
+	docs.Given("Given existing repositories crossref.helm-deployment and not-crossref.implementation")
+	deplRepoBody := tstRepository()
+	deplRepoResponse, err := tstPerformPost("/rest/api/v1/repositories/crossref.helm-deployment", token, &deplRepoBody)
+	require.Nil(t, err)
+	require.Equal(t, http.StatusCreated, deplRepoResponse.status)
+
+	implRepoBody := tstRepository()
+	implRepoResponse, err := tstPerformPost("/rest/api/v1/repositories/not-crossref.implementation", token, &implRepoBody)
+	require.Nil(t, err)
+	require.Equal(t, http.StatusCreated, implRepoResponse.status)
+
+	docs.Given("Given an existing service that references only the helm-deployment repository")
+	createBody := tstService("crossref")
+	createBody.Repositories = []string{
+		"crossref.helm-deployment",
+	}
+	createResponse, err := tstPerformPost("/rest/api/v1/services/crossref", token, &createBody)
+	require.Nil(t, err)
+	require.Equal(t, http.StatusCreated, createResponse.status)
+	// need commit hash from response, so we can perform valid update
+	var tmp openapi.ServiceDto
+	err = json.Unmarshal([]byte(createResponse.body), &tmp)
+	require.Nil(t, err)
+
+	docs.When("When they perform a valid patch of the service that adds a crossreferenced repository")
+	body := tstServicePatch()
+	body.Repositories = []string{
+		"crossref.helm-deployment",
+		"not-crossref.implementation",
+	}
+	body.CommitHash = tmp.CommitHash
+	response, err := tstPerformPatch("/rest/api/v1/services/crossref", token, &body)
+
+	docs.Then("Then the request is successful")
+	require.Nil(t, err)
+	require.Equal(t, http.StatusOK, response.status)
+
+	docs.Then("And the service has been correctly written, committed and pushed")
+	filename := "owners/some-owner/services/crossref.yaml"
+	expectedYaml := strings.ReplaceAll(tstServiceExpectedYaml("crossref"), "crossref/implementation", "not-crossref/implementation")
+	require.Equal(t, expectedYaml, metadataImpl.ReadContents(filename))
+	require.True(t, metadataImpl.FilesCommitted[filename])
+	require.True(t, metadataImpl.Pushed)
+
+	docs.Then("And the service has been cached and can be read again, returning the correct information")
+	readAgain, err := tstPerformGet("/rest/api/v1/services/crossref", tstUnauthenticated())
+	tstAssert(t, readAgain, err, http.StatusOK, "service-patch-crossref.json")
+
+	docs.Then("And a kafka message notifying other instances of the update has been sent")
+	require.Equal(t, 4, len(kafkaImpl.Recording)) // the initial inserts also cause kafka messages
+	actual, _ := json.Marshal(kafkaImpl.Recording[3])
+	require.Equal(t, tstServiceExpectedKafka("crossref"), string(actual))
+}
+
+func TestPATCHService_ImplementationCrossref_ChangeOwner(t *testing.T) {
+	tstReset()
+
+	docs.Given("Given an authenticated admin user")
+	token := tstValidAdminToken()
+
+	docs.Given("Given existing repositories crossref.helm-deployment and not-crossref.implementation")
+	deplRepoBody := tstRepository()
+	deplRepoResponse, err := tstPerformPost("/rest/api/v1/repositories/crossref.helm-deployment", token, &deplRepoBody)
+	require.Nil(t, err)
+	require.Equal(t, http.StatusCreated, deplRepoResponse.status)
+
+	implRepoBody := tstRepository()
+	implRepoResponse, err := tstPerformPost("/rest/api/v1/repositories/not-crossref.implementation", token, &implRepoBody)
+	require.Nil(t, err)
+	require.Equal(t, http.StatusCreated, implRepoResponse.status)
+
+	docs.Given("Given an existing service that references both these repositories, one of which is a cross reference")
+	createBody := tstService("crossref")
+	createBody.Repositories = []string{
+		"crossref.helm-deployment",
+		"not-crossref.implementation",
+	}
+	createResponse, err := tstPerformPost("/rest/api/v1/services/crossref", token, &createBody)
+	require.Nil(t, err)
+	require.Equal(t, http.StatusCreated, createResponse.status)
+	// need commit hash from response, so we can perform valid update
+	var tmp openapi.ServiceDto
+	err = json.Unmarshal([]byte(createResponse.body), &tmp)
+	require.Nil(t, err)
+
+	docs.When("When they perform a valid patch of the service that moves it to a new owner")
+	body := tstServicePatch()
+	body.Owner = p("deleteme")
+	body.CommitHash = tmp.CommitHash
+	response, err := tstPerformPatch("/rest/api/v1/services/crossref", token, &body)
+
+	docs.Then("Then the request is successful")
+	require.Nil(t, err)
+	require.Equal(t, http.StatusOK, response.status)
+
+	docs.Then("And the service with its referenced repositories has been correctly moved, committed and pushed, including the cross-referenced repository")
+	filename1old := "owners/some-owner/services/crossref.yaml"
+	filename1 := "owners/deleteme/services/crossref.yaml"
+	filename2old := "owners/some-owner/repositories/crossref.helm-deployment.yaml"
+	filename2 := "owners/deleteme/repositories/crossref.helm-deployment.yaml"
+	filename3old := "owners/some-owner/repositories/not-crossref.implementation.yaml"
+	filename3 := "owners/deleteme/repositories/not-crossref.implementation.yaml"
+	expectedYaml := strings.ReplaceAll(tstServiceExpectedYaml("crossref"), "crossref/implementation", "not-crossref/implementation")
+	require.Equal(t, expectedYaml, metadataImpl.ReadContents(filename1))
+	require.True(t, metadataImpl.FilesCommitted[filename1])
+	require.True(t, metadataImpl.FilesCommitted[filename1old])
+	require.True(t, metadataImpl.FilesCommitted[filename2])
+	require.True(t, metadataImpl.FilesCommitted[filename2old])
+	require.True(t, metadataImpl.FilesCommitted[filename3])
+	require.True(t, metadataImpl.FilesCommitted[filename3old])
+	require.True(t, metadataImpl.Pushed)
+
+	docs.Then("And the service has been cached and can be read again, returning the correct owner")
+	readAgain, err := tstPerformGet("/rest/api/v1/services/crossref", tstUnauthenticated())
+	tstAssert(t, readAgain, err, http.StatusOK, "service-patch-crossref-ownerchange.json")
+
+	docs.Then("And a kafka message notifying other instances of the update has been sent")
+	require.Equal(t, 4, len(kafkaImpl.Recording)) // the initial inserts also cause kafka messages
+	actual, _ := json.Marshal(kafkaImpl.Recording[3])
+	expectedMsg := strings.ReplaceAll(tstServiceMovedExpectedKafka("crossref"), "crossref.implementation", "not-crossref.implementation")
+	require.Equal(t, expectedMsg, string(actual))
 }
 
 // delete service

--- a/test/acceptance/util_setup_test.go
+++ b/test/acceptance/util_setup_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Interhyp/metadata-service/internal/web/app"
 	"github.com/Interhyp/metadata-service/internal/web/middleware/jwt"
 	"github.com/Interhyp/metadata-service/internal/web/server"
+	"github.com/Interhyp/metadata-service/test/acceptance/bitbucketmock"
 	"github.com/Interhyp/metadata-service/test/acceptance/idpmock"
 	"github.com/Interhyp/metadata-service/test/acceptance/kafkamock"
 	"github.com/Interhyp/metadata-service/test/acceptance/metadatamock"
@@ -37,6 +38,7 @@ var (
 	metadataImpl *metadatamock.Impl
 	kafkaImpl    *kafkamock.Impl
 	idpImpl      *idpmock.Impl
+	bbImpl       *bitbucketmock.BitbucketMock
 
 	application application2.Application
 	appCtx      context.Context
@@ -60,6 +62,7 @@ func tstSetup(configPath string) error {
 	metadataImpl = metadatamock.New().(*metadatamock.Impl)
 	kafkaImpl = kafkamock.New().(*kafkamock.Impl)
 	idpImpl = idpmock.New().(*idpmock.Impl)
+	bbImpl = bitbucketmock.New().(*bitbucketmock.BitbucketMock)
 
 	application.Register()
 
@@ -72,6 +75,7 @@ func tstSetup(configPath string) error {
 	registry.CreateOverride(repository.MetadataAcornName, metadataImpl)
 	registry.CreateOverride(repository.KafkaAcornName, kafkaImpl)
 	registry.CreateOverride(repository.IdentityProviderAcornName, idpImpl)
+	registry.CreateOverride(repository.BitbucketAcornName, bbImpl)
 
 	registry.SkipAssemble(loggingImpl) // already assembled
 	registry.SkipAssemble(configImpl)  // would attempt to read config

--- a/test/resources/acceptance-expected/repository-invalid-key.json
+++ b/test/resources/acceptance-expected/repository-invalid-key.json
@@ -1,5 +1,5 @@
 {
-  "details": "repository name must match ^[a-z](-?[a-z0-9]+)*$, is not allowed to match ^$ and may have up to 64 characters; repository type must be one of [implementation deployment api helm-chart] and name and type must be separated by a . character",
+  "details": "repository name must match ^[a-z](-?[a-z0-9]+)*$, is not allowed to match ^$ and may have up to 64 characters; repository type must be one of [implementation helm-deployment api helm-chart] and name and type must be separated by a . character",
   "message": "repository.invalid",
   "timestamp": "2022-11-06T18:14:10Z"
 }

--- a/test/resources/acceptance-expected/service-create-crossref.json
+++ b/test/resources/acceptance-expected/service-create-crossref.json
@@ -1,0 +1,22 @@
+{
+  "alertTarget": "squad_nothing@some-organisation.com",
+  "commitHash": "6c8ac2c35791edf9979623c717a2430000000000",
+  "developmentOnly": false,
+  "jiraIssue": "ISSUE-2345",
+  "owner": "some-owner",
+  "quicklinks": [
+    {
+      "title": "Swagger UI",
+      "url": "/swagger-ui/index.html"
+    }
+  ],
+  "repositories": [
+    "crossref.helm-deployment",
+    "not-crossref.implementation"
+  ],
+  "requiredScans": [
+    "SAST",
+    "SCA"
+  ],
+  "timeStamp": "2022-11-06T18:14:10Z"
+}

--- a/test/resources/acceptance-expected/service-create-invalid-values.json
+++ b/test/resources/acceptance-expected/service-create-invalid-values.json
@@ -1,5 +1,5 @@
 {
-  "details": "validation error: repository key must belong to service and have acceptable type",
+  "details": "validation error: repository key must have acceptable name and type combination (allowed types: api implementation helm-deployment), and for helm-deployment the name must match the service name",
   "message": "service.invalid.values",
   "timestamp": "2022-11-06T18:14:10Z"
 }

--- a/test/resources/acceptance-expected/service-patch-crossref-ownerchange.json
+++ b/test/resources/acceptance-expected/service-patch-crossref-ownerchange.json
@@ -1,0 +1,22 @@
+{
+  "alertTarget": "squad_nothing@some-organisation.com",
+  "commitHash": "6c8ac2c35791edf9979623c717a2430000000000",
+  "developmentOnly": false,
+  "jiraIssue": "ISSUE-2345",
+  "owner": "deleteme",
+  "quicklinks": [
+    {
+      "title": "Swagger UI",
+      "url": "/swagger-ui/index.html"
+    }
+  ],
+  "repositories": [
+    "crossref.helm-deployment",
+    "not-crossref.implementation"
+  ],
+  "requiredScans": [
+    "SAST",
+    "SCA"
+  ],
+  "timeStamp": "2022-11-06T18:14:10Z"
+}

--- a/test/resources/acceptance-expected/service-patch-crossref.json
+++ b/test/resources/acceptance-expected/service-patch-crossref.json
@@ -1,0 +1,22 @@
+{
+  "alertTarget": "squad_nothing@some-organisation.com",
+  "commitHash": "6c8ac2c35791edf9979623c717a2430000000000",
+  "developmentOnly": false,
+  "jiraIssue": "ISSUE-2345",
+  "owner": "some-owner",
+  "quicklinks": [
+    {
+      "title": "Swagger UI",
+      "url": "/swagger-ui/index.html"
+    }
+  ],
+  "repositories": [
+    "crossref.helm-deployment",
+    "not-crossref.implementation"
+  ],
+  "requiredScans": [
+    "SAST",
+    "SCA"
+  ],
+  "timeStamp": "2022-11-06T18:14:10Z"
+}

--- a/test/resources/valid-config.yaml
+++ b/test/resources/valid-config.yaml
@@ -19,4 +19,4 @@ SERVICE_NAME_PROHIBITED_REGEX: "-service$"
 
 OWNER_ALIAS_FILTER_REGEX: .*
 
-REPOSITORY_TYPES: 'implementation,deployment,api,helm-chart'
+REPOSITORY_TYPES: 'implementation,helm-deployment,api,helm-chart'


### PR DESCRIPTION
# Description

We noticed that the update service endpoints did not allow referencing a monorepo. This PR makes the necessary changes, and expands the acceptance test coverage.

Fixes RELTEC-10917 (internal issue)

# Checklist

- [x] I have read the [CONTRIBUTING.md](/CONTRIBUTING-template.md)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no lint errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] Only MIT licensed or MIT license compatible dependencies are used (e.g.: Apache2 or BSD)
- [x] The code contains no credentials, personalized data or company secrets