### PR TITLE
Notify everytime

### DIFF
--- a/internal/repository/notifier/notifier.go
+++ b/internal/repository/notifier/notifier.go
@@ -32,8 +32,8 @@ var (
 	_ repository.Notifier = (*Impl)(nil)
 )
 
-func AsPayload(dto interface{}) openapi.NotificationPayload {
-	switch cast := dto.(type) {
+func AsPayload[T openapi.OwnerDto | openapi.ServiceDto | openapi.RepositoryDto](dto T) openapi.NotificationPayload {
+	switch cast := any(dto).(type) {
 	case openapi.OwnerDto:
 		return openapi.NotificationPayload{
 			Owner: &cast,
@@ -131,9 +131,9 @@ func (r *Impl) publish(ctx context.Context,
 				asyncCtx, timeoutCtxCancel := context.WithTimeout(copyCtx, webhookContextTimeout)
 
 				go func(withClient notifierclient.NotifierClient) {
-					defer r.recoverPanic(asyncCtx)
 					defer cancel()
 					defer timeoutCtxCancel()
+					defer r.recoverPanic(asyncCtx)
 					withClient.Send(asyncCtx, notification)
 				}(client)
 			}

--- a/internal/service/owners/acorn.go
+++ b/internal/service/owners/acorn.go
@@ -2,7 +2,6 @@ package owners
 
 import (
 	"context"
-	"github.com/Interhyp/metadata-service/internal/acorn/repository"
 	"github.com/Interhyp/metadata-service/internal/acorn/service"
 	"github.com/StephanHCB/go-autumn-acorn-registry/api"
 	auzerolog "github.com/StephanHCB/go-autumn-logging-zerolog"
@@ -28,7 +27,6 @@ func (s *Impl) AssembleAcorn(registry auacornapi.AcornRegistry) error {
 	s.Logging = registry.GetAcornByName(librepo.LoggingAcornName).(librepo.Logging)
 	s.Cache = registry.GetAcornByName(service.CacheAcornName).(service.Cache)
 	s.Updater = registry.GetAcornByName(service.UpdaterAcornName).(service.Updater)
-	s.Notifier = registry.GetAcornByName(repository.NotifierAcornName).(repository.Notifier)
 
 	s.Timestamp = registry.GetAcornByName(librepo.TimestampAcornName).(librepo.Timestamp)
 
@@ -49,10 +47,6 @@ func (s *Impl) SetupAcorn(registry auacornapi.AcornRegistry) error {
 		return err
 	}
 	err = registry.SetupAfter(s.Updater.(auacornapi.Acorn))
-	if err != nil {
-		return err
-	}
-	err = registry.SetupAfter(s.Notifier.(auacornapi.Acorn))
 	if err != nil {
 		return err
 	}

--- a/internal/service/owners/owners.go
+++ b/internal/service/owners/owners.go
@@ -4,10 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/Interhyp/metadata-service/api"
-	"github.com/Interhyp/metadata-service/internal/acorn/repository"
 	"github.com/Interhyp/metadata-service/internal/acorn/service"
-	"github.com/Interhyp/metadata-service/internal/repository/notifier"
-	"github.com/Interhyp/metadata-service/internal/types"
 	"strings"
 
 	librepo "github.com/StephanHCB/go-backend-service-common/acorns/repository"
@@ -19,7 +16,6 @@ type Impl struct {
 	Logging       librepo.Logging
 	Cache         service.Cache
 	Updater       service.Updater
-	Notifier      repository.Notifier
 
 	Timestamp librepo.Timestamp
 }
@@ -84,7 +80,6 @@ func (s *Impl) CreateOwner(ctx context.Context, ownerAlias string, ownerCreateDt
 		if err != nil {
 			return err
 		}
-		err = s.Notifier.PublishCreation(ctx, ownerAlias, notifier.AsPayload(ownerDto))
 		if err != nil {
 			s.Logging.Logger().Ctx(ctx).Warn().WithErr(err).Printf("error publishing creation of owner %s", ownerAlias)
 		}
@@ -149,10 +144,6 @@ func (s *Impl) UpdateOwner(ctx context.Context, ownerAlias string, ownerDto open
 		if err != nil {
 			return err
 		}
-		err = s.Notifier.PublishModification(ctx, ownerAlias, notifier.AsPayload(ownerDto))
-		if err != nil {
-			s.Logging.Logger().Ctx(ctx).Warn().WithErr(err).Printf("error publishing modification of owner %s", ownerAlias)
-		}
 		result = ownerWritten
 		return nil
 	})
@@ -210,10 +201,6 @@ func (s *Impl) PatchOwner(ctx context.Context, ownerAlias string, ownerPatchDto 
 		ownerWritten, err := s.Updater.WriteOwner(subCtx, ownerAlias, ownerDto)
 		if err != nil {
 			return err
-		}
-		err = s.Notifier.PublishModification(ctx, ownerAlias, notifier.AsPayload(ownerDto))
-		if err != nil {
-			s.Logging.Logger().Ctx(ctx).Warn().WithErr(err).Printf("error publishing modification of owner %s", ownerAlias)
 		}
 
 		result = ownerWritten
@@ -315,7 +302,6 @@ func (s *Impl) DeleteOwner(ctx context.Context, ownerAlias string, deletionInfo 
 		if err != nil {
 			return err
 		}
-		s.Notifier.PublishDeletion(ctx, ownerAlias, types.OwnerPayload)
 
 		return nil
 	})

--- a/internal/service/repositories/acorn.go
+++ b/internal/service/repositories/acorn.go
@@ -3,7 +3,6 @@ package repositories
 import (
 	"context"
 	"github.com/Interhyp/metadata-service/internal/acorn/config"
-	"github.com/Interhyp/metadata-service/internal/acorn/repository"
 	"github.com/Interhyp/metadata-service/internal/acorn/service"
 	"github.com/StephanHCB/go-autumn-acorn-registry/api"
 	auzerolog "github.com/StephanHCB/go-autumn-logging-zerolog"
@@ -30,7 +29,6 @@ func (s *Impl) AssembleAcorn(registry auacornapi.AcornRegistry) error {
 	s.Cache = registry.GetAcornByName(service.CacheAcornName).(service.Cache)
 	s.Updater = registry.GetAcornByName(service.UpdaterAcornName).(service.Updater)
 	s.Owners = registry.GetAcornByName(service.OwnersAcornName).(service.Owners)
-	s.Notifier = registry.GetAcornByName(repository.NotifierAcornName).(repository.Notifier)
 
 	s.CustomConfiguration = config.Custom(s.Configuration)
 
@@ -57,10 +55,6 @@ func (s *Impl) SetupAcorn(registry auacornapi.AcornRegistry) error {
 		return err
 	}
 	err = registry.SetupAfter(s.Owners.(auacornapi.Acorn))
-	if err != nil {
-		return err
-	}
-	err = registry.SetupAfter(s.Notifier.(auacornapi.Acorn))
 	if err != nil {
 		return err
 	}

--- a/internal/service/repositories/repositories.go
+++ b/internal/service/repositories/repositories.go
@@ -5,11 +5,8 @@ import (
 	"fmt"
 	"github.com/Interhyp/metadata-service/api"
 	"github.com/Interhyp/metadata-service/internal/acorn/config"
-	"github.com/Interhyp/metadata-service/internal/acorn/repository"
 	"github.com/Interhyp/metadata-service/internal/acorn/service"
-	"github.com/Interhyp/metadata-service/internal/repository/notifier"
 	"github.com/Interhyp/metadata-service/internal/service/util"
-	"github.com/Interhyp/metadata-service/internal/types"
 	librepo "github.com/StephanHCB/go-backend-service-common/acorns/repository"
 	"github.com/StephanHCB/go-backend-service-common/api/apierrors"
 	"net/url"
@@ -22,7 +19,6 @@ type Impl struct {
 	Cache         service.Cache
 	Updater       service.Updater
 	Owners        service.Owners
-	Notifier      repository.Notifier
 
 	CustomConfiguration config.CustomConfiguration
 	Timestamp           librepo.Timestamp
@@ -181,10 +177,7 @@ func (s *Impl) CreateRepository(ctx context.Context, key string, repositoryCreat
 		if err != nil {
 			return err
 		}
-		err = s.Notifier.PublishCreation(ctx, key, notifier.AsPayload(repositoryDto))
-		if err != nil {
-			s.Logging.Logger().Ctx(ctx).Warn().WithErr(err).Printf("error publishing creation of repository %s", key)
-		}
+
 		result = repositoryWritten
 		return nil
 	})
@@ -255,10 +248,6 @@ func (s *Impl) UpdateRepository(ctx context.Context, key string, repositoryDto o
 		repositoryWritten, err := s.Updater.WriteRepository(subCtx, key, repositoryDto)
 		if err != nil {
 			return err
-		}
-		err = s.Notifier.PublishModification(ctx, key, notifier.AsPayload(repositoryDto))
-		if err != nil {
-			s.Logging.Logger().Ctx(ctx).Warn().WithErr(err).Printf("error publishing modification of repository %s", key)
 		}
 
 		result = repositoryWritten
@@ -332,10 +321,7 @@ func (s *Impl) PatchRepository(ctx context.Context, key string, repositoryPatchD
 		if err != nil {
 			return err
 		}
-		err = s.Notifier.PublishModification(ctx, key, notifier.AsPayload(repositoryDto))
-		if err != nil {
-			s.Logging.Logger().Ctx(ctx).Warn().WithErr(err).Printf("error publishing modification of repository %s", key)
-		}
+		
 		result = repositoryWritten
 		return nil
 	})
@@ -538,7 +524,6 @@ func (s *Impl) DeleteRepository(ctx context.Context, key string, deletionInfo op
 		if err != nil {
 			return err
 		}
-		s.Notifier.PublishDeletion(ctx, key, types.RepositoryPayload)
 
 		return nil
 	})

--- a/internal/service/services/acorn.go
+++ b/internal/service/services/acorn.go
@@ -3,7 +3,6 @@ package services
 import (
 	"context"
 	"github.com/Interhyp/metadata-service/internal/acorn/config"
-	"github.com/Interhyp/metadata-service/internal/acorn/repository"
 	"github.com/Interhyp/metadata-service/internal/acorn/service"
 	"github.com/StephanHCB/go-autumn-acorn-registry/api"
 	auzerolog "github.com/StephanHCB/go-autumn-logging-zerolog"
@@ -31,7 +30,6 @@ func (s *Impl) AssembleAcorn(registry auacornapi.AcornRegistry) error {
 	s.Updater = registry.GetAcornByName(service.UpdaterAcornName).(service.Updater)
 	s.Owner = registry.GetAcornByName(service.OwnersAcornName).(service.Owners)
 	s.Repositories = registry.GetAcornByName(service.RepositoriesAcornName).(service.Repositories)
-	s.Notifier = registry.GetAcornByName(repository.NotifierAcornName).(repository.Notifier)
 
 	s.CustomConfiguration = config.Custom(s.Configuration)
 
@@ -62,10 +60,6 @@ func (s *Impl) SetupAcorn(registry auacornapi.AcornRegistry) error {
 		return err
 	}
 	err = registry.SetupAfter(s.Repositories.(auacornapi.Acorn))
-	if err != nil {
-		return err
-	}
-	err = registry.SetupAfter(s.Notifier.(auacornapi.Acorn))
 	if err != nil {
 		return err
 	}

--- a/internal/service/services/services.go
+++ b/internal/service/services/services.go
@@ -6,10 +6,7 @@ import (
 	"fmt"
 	"github.com/Interhyp/metadata-service/api"
 	"github.com/Interhyp/metadata-service/internal/acorn/config"
-	"github.com/Interhyp/metadata-service/internal/acorn/repository"
 	"github.com/Interhyp/metadata-service/internal/acorn/service"
-	"github.com/Interhyp/metadata-service/internal/repository/notifier"
-	"github.com/Interhyp/metadata-service/internal/types"
 	"strings"
 
 	librepo "github.com/StephanHCB/go-backend-service-common/acorns/repository"
@@ -24,7 +21,6 @@ type Impl struct {
 	Updater             service.Updater
 	Owner               service.Owners
 	Repositories        service.Repositories
-	Notifier            repository.Notifier
 
 	Timestamp librepo.Timestamp
 }
@@ -97,10 +93,7 @@ func (s *Impl) CreateService(ctx context.Context, serviceName string, serviceCre
 		if err != nil {
 			return err
 		}
-		err = s.Notifier.PublishCreation(ctx, serviceName, notifier.AsPayload(serviceDto))
-		if err != nil {
-			s.Logging.Logger().Ctx(ctx).Warn().WithErr(err).Printf("error publishing creation of service %s", serviceName)
-		}
+
 		result = serviceWritten
 		return nil
 	})
@@ -187,10 +180,7 @@ func (s *Impl) UpdateService(ctx context.Context, serviceName string, serviceDto
 		if err != nil {
 			return err
 		}
-		err = s.Notifier.PublishModification(ctx, serviceName, notifier.AsPayload(serviceDto))
-		if err != nil {
-			s.Logging.Logger().Ctx(ctx).Warn().WithErr(err).Printf("error publishing modification of service %s", serviceName)
-		}
+
 		result = serviceWritten
 		return nil
 	})
@@ -274,10 +264,7 @@ func (s *Impl) PatchService(ctx context.Context, serviceName string, servicePatc
 		if err != nil {
 			return err
 		}
-		err = s.Notifier.PublishModification(ctx, serviceName, notifier.AsPayload(serviceDto))
-		if err != nil {
-			s.Logging.Logger().Ctx(ctx).Warn().WithErr(err).Printf("error publishing modification of service %s", serviceName)
-		}
+
 		result = serviceWritten
 		return nil
 	})
@@ -411,8 +398,6 @@ func (s *Impl) DeleteService(ctx context.Context, serviceName string, deletionIn
 		if err != nil {
 			return err
 		}
-
-		s.Notifier.PublishDeletion(ctx, serviceName, types.ServicePayload)
 
 		return nil
 	})

--- a/internal/service/updater/acorn.go
+++ b/internal/service/updater/acorn.go
@@ -31,6 +31,7 @@ func (s *Impl) AssembleAcorn(registry auacornapi.AcornRegistry) error {
 	s.Configuration = registry.GetAcornByName(librepo.ConfigurationAcornName).(librepo.Configuration)
 	s.Logging = registry.GetAcornByName(librepo.LoggingAcornName).(librepo.Logging)
 	s.Kafka = registry.GetAcornByName(repository.KafkaAcornName).(repository.Kafka)
+	s.Notifier = registry.GetAcornByName(repository.NotifierAcornName).(repository.Notifier)
 	s.Mapper = registry.GetAcornByName(service.MapperAcornName).(service.Mapper)
 	s.Cache = registry.GetAcornByName(service.CacheAcornName).(service.Cache)
 
@@ -49,6 +50,10 @@ func (s *Impl) SetupAcorn(registry auacornapi.AcornRegistry) error {
 		return err
 	}
 	err = registry.SetupAfter(s.Kafka.(auacornapi.Acorn))
+	if err != nil {
+		return err
+	}
+	err = registry.SetupAfter(s.Notifier.(auacornapi.Acorn))
 	if err != nil {
 		return err
 	}

--- a/internal/service/updater/repositories.go
+++ b/internal/service/updater/repositories.go
@@ -6,6 +6,8 @@ import (
 	"github.com/Interhyp/metadata-service/api"
 	"github.com/Interhyp/metadata-service/internal/acorn/errors/nochangeserror"
 	"github.com/Interhyp/metadata-service/internal/acorn/repository"
+	"github.com/Interhyp/metadata-service/internal/repository/notifier"
+	"github.com/Interhyp/metadata-service/internal/types"
 	"github.com/StephanHCB/go-backend-service-common/api/apierrors"
 )
 
@@ -157,6 +159,7 @@ func (s *Impl) updateIndividualRepositories(ctx context.Context, repositoryKeysM
 		if activity == removeExisting {
 			s.Logging.Logger().Ctx(ctx).Info().Printf("repository %s is no longer current, removing it from the cache", key)
 			s.Cache.DeleteRepository(ctx, key)
+			s.Notifier.PublishDeletion(ctx, key, types.RepositoryPayload)
 		} else {
 			isNew := activity == addNew
 			err := s.updateIndividualRepository(ctx, key, isNew)
@@ -196,8 +199,16 @@ func (s *Impl) updateIndividualRepository(ctx context.Context, key string, isNew
 	} else {
 		s.Cache.PutRepository(ctx, key, repository)
 		if isNew {
+			err = s.Notifier.PublishCreation(ctx, key, notifier.AsPayload(repository))
+			if err != nil {
+				s.Logging.Logger().Ctx(ctx).Warn().WithErr(err).Printf("error publishing creation of repository %s", key)
+			}
 			s.Logging.Logger().Ctx(ctx).Info().Printf("new repository %s added to cache", key)
 		} else {
+			err = s.Notifier.PublishModification(ctx, key, notifier.AsPayload(repository))
+			if err != nil {
+				s.Logging.Logger().Ctx(ctx).Warn().WithErr(err).Printf("error publishing modification of repository %s", key)
+			}
 			s.Logging.Logger().Ctx(ctx).Debug().Printf("repository %s updated in cache", key)
 		}
 	}

--- a/internal/service/updater/updater.go
+++ b/internal/service/updater/updater.go
@@ -18,6 +18,7 @@ type Impl struct {
 	CustomConfiguration config.CustomConfiguration
 	Logging             librepo.Logging
 	Kafka               repository.Kafka
+	Notifier            repository.Notifier
 	Mapper              service.Mapper
 	Cache               service.Cache
 

--- a/test/acceptance/ownerctl_acc_test.go
+++ b/test/acceptance/ownerctl_acc_test.go
@@ -83,7 +83,7 @@ func TestPOSTOwner_Success(t *testing.T) {
 	require.Equal(t, tstOwnerExpectedKafka("post-owner-success"), string(actual))
 
 	docs.Then("And a notification has been sent to all matching consumers")
-	payload := tstCreateOwnerPayload()
+	payload := tstNewOwnerPayload()
 	hasSentNotification(t, "receivesCreate", "post-owner-success", types.CreatedEvent, types.OwnerPayload, &payload)
 	hasSentNotification(t, "receivesOwner", "post-owner-success", types.CreatedEvent, types.OwnerPayload, &payload)
 }
@@ -286,7 +286,7 @@ func TestPUTOwner_Success(t *testing.T) {
 	require.Equal(t, tstOwnerExpectedKafka("some-owner"), string(actual))
 
 	docs.Then("And a notification has been sent to all matching consumers")
-	payload := tstPutOwnerPayload()
+	payload := tstNewOwnerPayload()
 	hasSentNotification(t, "receivesModified", "some-owner", types.ModifiedEvent, types.OwnerPayload, &payload)
 	hasSentNotification(t, "receivesOwner", "some-owner", types.ModifiedEvent, types.OwnerPayload, &payload)
 }
@@ -519,7 +519,7 @@ func TestPATCHOwner_Success(t *testing.T) {
 	require.Equal(t, tstOwnerExpectedKafka("some-owner"), string(actual))
 
 	docs.Then("And a notification has been sent to all matching consumers")
-	payload := tstPatchOwnerPayload()
+	payload := tstUpdatedOwnerPayload()
 	hasSentNotification(t, "receivesModified", "some-owner", types.ModifiedEvent, types.OwnerPayload, &payload)
 	hasSentNotification(t, "receivesOwner", "some-owner", types.ModifiedEvent, types.OwnerPayload, &payload)
 }

--- a/test/acceptance/repositoryctl_acc_test.go
+++ b/test/acceptance/repositoryctl_acc_test.go
@@ -135,7 +135,7 @@ func TestPOSTRepository_Success(t *testing.T) {
 	require.Equal(t, tstRepositoryExpectedKafka("new-repository.api"), string(actual))
 
 	docs.Then("And a notification has been sent to all matching owners")
-	payload := tstPostRepositoryPayload()
+	payload := tstNewRepositoryPayload()
 	hasSentNotification(t, "receivesCreate", "new-repository.api", types.CreatedEvent, types.RepositoryPayload, &payload)
 	hasSentNotification(t, "receivesRepository", "new-repository.api", types.CreatedEvent, types.RepositoryPayload, &payload)
 }
@@ -339,7 +339,7 @@ func TestPUTRepository_Success(t *testing.T) {
 	require.Equal(t, tstRepositoryExpectedKafka("karma-wrapper.helm-chart"), string(actual))
 
 	docs.Then("And a notification has been sent to all matching owners")
-	payload := tstPutRepositoryPayload()
+	payload := tstNewRepositoryPayload()
 	hasSentNotification(t, "receivesModified", "karma-wrapper.helm-chart", types.ModifiedEvent, types.RepositoryPayload, &payload)
 	hasSentNotification(t, "receivesRepository", "karma-wrapper.helm-chart", types.ModifiedEvent, types.RepositoryPayload, &payload)
 }
@@ -627,7 +627,7 @@ func TestPATCHRepository_Success(t *testing.T) {
 	require.Equal(t, tstRepositoryExpectedKafka("karma-wrapper.helm-chart"), string(actual))
 
 	docs.Then("And a notification has been sent to all matching owners")
-	payload := tstPatchRepositoryPayload()
+	payload := tstUpdatedRepositoryPayload()
 	hasSentNotification(t, "receivesModified", "karma-wrapper.helm-chart", types.ModifiedEvent, types.RepositoryPayload, &payload)
 	hasSentNotification(t, "receivesRepository", "karma-wrapper.helm-chart", types.ModifiedEvent, types.RepositoryPayload, &payload)
 }

--- a/test/acceptance/repositoryctl_acc_test.go
+++ b/test/acceptance/repositoryctl_acc_test.go
@@ -837,7 +837,7 @@ func TestPATCHRepository_ChangeOwner(t *testing.T) {
 	token := tstValidAdminToken()
 
 	docs.When("When they perform a valid patch of an existing repository that changes its owner")
-	body := tstRepositoryPatch()
+	body := tstRepositoryUnchangedPatch()
 	body.Owner = p("deleteme")
 	response, err := tstPerformPatch("/rest/api/v1/repositories/karma-wrapper.helm-chart", token, &body)
 
@@ -847,7 +847,7 @@ func TestPATCHRepository_ChangeOwner(t *testing.T) {
 	docs.Then("And the repository with its repositories has been correctly moved, committed and pushed")
 	filename1old := "owners/some-owner/repositories/karma-wrapper.helm-chart.yaml"
 	filename1 := "owners/deleteme/repositories/karma-wrapper.helm-chart.yaml"
-	require.Equal(t, tstRepositoryExpectedYamlKarmaWrapper(), metadataImpl.ReadContents(filename1))
+	require.Equal(t, tstRepositoryUnchangedExpectedYaml(), metadataImpl.ReadContents(filename1))
 	require.True(t, metadataImpl.FilesCommitted[filename1])
 	require.True(t, metadataImpl.FilesCommitted[filename1old])
 	require.True(t, metadataImpl.Pushed)

--- a/test/acceptance/servicectl_acc_test.go
+++ b/test/acceptance/servicectl_acc_test.go
@@ -86,7 +86,7 @@ func TestPOSTService_Success(t *testing.T) {
 	require.Equal(t, tstServiceExpectedKafka("whatever"), string(actual))
 
 	docs.Then("And a notification has been sent to all matching owners")
-	payload := tstPostServicePayload("whatever")
+	payload := tstNewServicePayload("whatever")
 	hasSentNotification(t, "receivesCreate", "whatever", types.CreatedEvent, types.ServicePayload, &payload)
 	hasSentNotification(t, "receivesService", "whatever", types.CreatedEvent, types.ServicePayload, &payload)
 }
@@ -365,7 +365,7 @@ func TestPUTService_Success(t *testing.T) {
 	require.Equal(t, tstServiceExpectedKafka("some-service-backend"), string(actual))
 
 	docs.Then("And a notification has been sent to all matching owners")
-	payload := tstPutServicePayload("some-service-backend")
+	payload := tstNewServicePayload("some-service-backend")
 	hasSentNotification(t, "receivesModified", "some-service-backend", types.ModifiedEvent, types.ServicePayload, &payload)
 	hasSentNotification(t, "receivesService", "some-service-backend", types.ModifiedEvent, types.ServicePayload, &payload)
 }
@@ -709,7 +709,7 @@ func TestPATCHService_Success(t *testing.T) {
 	require.Equal(t, tstServiceExpectedKafka("some-service-backend"), string(actual))
 
 	docs.Then("And a notification has been sent to all matching owners")
-	payload := tstPatchServicePayload("some-service-backend")
+	payload := tstUpdatedServicePayload("some-service-backend")
 	hasSentNotification(t, "receivesModified", "some-service-backend", types.ModifiedEvent, types.ServicePayload, &payload)
 	hasSentNotification(t, "receivesService", "some-service-backend", types.ModifiedEvent, types.ServicePayload, &payload)
 }

--- a/test/acceptance/util_dtos_test.go
+++ b/test/acceptance/util_dtos_test.go
@@ -59,27 +59,16 @@ func tstOwnerUnchangedPatch() openapi.OwnerPatchDto {
 	}
 }
 
-func tstCreateOwnerPayload() openapi.NotificationPayload {
-	return notifier.AsPayload(openapi.OwnerDto{
-		Contact:            "somebody@some-organisation.com",
-		ProductOwner:       p("kschlangenheld"),
-		DefaultJiraProject: p("JIRA"),
-		JiraIssue:          "ISSUE-2345",
-	})
-}
-func tstPutOwnerPayload() openapi.NotificationPayload {
-	return notifier.AsPayload(tstOwner())
+func tstNewOwnerPayload() openapi.NotificationPayload {
+	owner := tstOwner()
+	owner.CommitHash = "6c8ac2c35791edf9979623c717a2430000000000"
+	return notifier.AsPayload(owner)
 }
 
-func tstPatchOwnerPayload() openapi.NotificationPayload {
-	return notifier.AsPayload(openapi.OwnerDto{
-		Contact:            "somebody@some-organisation.com",
-		ProductOwner:       p("kschlangenheldt"),
-		DefaultJiraProject: p("ISSUE"),
-		JiraIssue:          "ISSUE-2345",
-		TimeStamp:          "2022-11-06T18:14:10Z",
-		CommitHash:         "6c8ac2c35791edf9979623c717a243fc53400000",
-	})
+func tstUpdatedOwnerPayload() openapi.NotificationPayload {
+	owner := tstOwnerUnchanged()
+	owner.CommitHash = "6c8ac2c35791edf9979623c717a2430000000000"
+	return notifier.AsPayload(owner)
 }
 
 func tstOwnerExpectedYaml() string {
@@ -219,19 +208,16 @@ func tstServiceMovedExpectedKafka(name string) string {
 		`"commitHash":"6c8ac2c35791edf9979623c717a2430000000000"}`
 }
 
-func tstPostServicePayload(name string) openapi.NotificationPayload {
-	repo := tstService(name)
-	repo.CommitHash = ""
-	repo.TimeStamp = ""
-	return notifier.AsPayload(repo)
+func tstNewServicePayload(name string) openapi.NotificationPayload {
+	service := tstService(name)
+	service.CommitHash = "6c8ac2c35791edf9979623c717a2430000000000"
+	return notifier.AsPayload(service)
 }
 
-func tstPutServicePayload(name string) openapi.NotificationPayload {
-	return notifier.AsPayload(tstService(name))
-}
-
-func tstPatchServicePayload(name string) openapi.NotificationPayload {
-	return notifier.AsPayload(tstService(name))
+func tstUpdatedServicePayload(name string) openapi.NotificationPayload {
+	service := tstService(name)
+	service.CommitHash = "6c8ac2c35791edf9979623c717a2430000000000"
+	return notifier.AsPayload(service)
 }
 
 // repository
@@ -352,17 +338,14 @@ func tstDelete() openapi.DeletionDto {
 	}
 }
 
-func tstPostRepositoryPayload() openapi.NotificationPayload {
+func tstNewRepositoryPayload() openapi.NotificationPayload {
 	repo := tstRepository()
-	repo.CommitHash = ""
-	repo.TimeStamp = ""
+	repo.CommitHash = "6c8ac2c35791edf9979623c717a2430000000000"
 	return notifier.AsPayload(repo)
 }
 
-func tstPutRepositoryPayload() openapi.NotificationPayload {
-	return notifier.AsPayload(tstRepository())
-}
-
-func tstPatchRepositoryPayload() openapi.NotificationPayload {
-	return notifier.AsPayload(tstRepositoryUnchanged())
+func tstUpdatedRepositoryPayload() openapi.NotificationPayload {
+	repo := tstRepositoryUnchanged()
+	repo.CommitHash = "6c8ac2c35791edf9979623c717a2430000000000"
+	return notifier.AsPayload(repo)
 }

--- a/test/acceptance/util_dtos_test.go
+++ b/test/acceptance/util_dtos_test.go
@@ -32,7 +32,7 @@ func tstOwner() openapi.OwnerDto {
 
 func tstOwnerPatch() openapi.OwnerPatchDto {
 	return openapi.OwnerPatchDto{
-		Contact:    p("somebody@some-organisation.com"),
+		Contact:    p("changed@some-organisation.com"),
 		TimeStamp:  "2022-11-06T18:14:10Z",
 		CommitHash: "6c8ac2c35791edf9979623c717a243fc53400000",
 		JiraIssue:  "ISSUE-2345",
@@ -68,6 +68,7 @@ func tstNewOwnerPayload() openapi.NotificationPayload {
 func tstUpdatedOwnerPayload() openapi.NotificationPayload {
 	owner := tstOwnerUnchanged()
 	owner.CommitHash = "6c8ac2c35791edf9979623c717a2430000000000"
+	owner.Contact = "changed@some-organisation.com"
 	return notifier.AsPayload(owner)
 }
 
@@ -86,7 +87,7 @@ defaultJiraProject: ISSUE
 }
 
 func tstOwnerPatchExpectedYaml() string {
-	return `contact: somebody@some-organisation.com
+	return `contact: changed@some-organisation.com
 productOwner: kschlangenheldt
 defaultJiraProject: ISSUE
 `
@@ -271,6 +272,7 @@ func tstRepositoryUnchanged() openapi.RepositoryDto {
 
 func tstRepositoryPatch() openapi.RepositoryPatchDto {
 	return openapi.RepositoryPatchDto{
+		Mainline:   p("main"),
 		TimeStamp:  "2022-11-06T18:14:10Z",
 		CommitHash: "6c8ac2c35791edf9979623c717a243fc53400000",
 		JiraIssue:  "ISSUE-2345",
@@ -314,7 +316,7 @@ configuration:
 
 func tstRepositoryExpectedYamlKarmaWrapper() string {
 	return `url: ssh://git@bitbucket.some-organisation.com:7999/helm/karma-wrapper.git
-mainline: master
+mainline: main
 unittest: false
 `
 }
@@ -346,6 +348,7 @@ func tstNewRepositoryPayload() openapi.NotificationPayload {
 
 func tstUpdatedRepositoryPayload() openapi.NotificationPayload {
 	repo := tstRepositoryUnchanged()
+	repo.Mainline = "main"
 	repo.CommitHash = "6c8ac2c35791edf9979623c717a2430000000000"
 	return notifier.AsPayload(repo)
 }

--- a/test/acceptance/util_notifier_test.go
+++ b/test/acceptance/util_notifier_test.go
@@ -11,11 +11,12 @@ import (
 func hasSentNotification(t *testing.T, clientIdentifier string, name string, event types.NotificationEventType, payloadType types.NotificationPayloadType, payload *openapi.NotificationPayload) {
 	client := notifierImpl.Clients[clientIdentifier]
 	mockClient := client.(*notifiermock.NotifierClientMock)
-
-	require.NotNil(t, mockClient.SentNotification)
-	sent := *mockClient.SentNotification
-	require.Equal(t, name, sent.Name)
-	require.Equal(t, event.String(), sent.Event)
-	require.Equal(t, payloadType.String(), sent.Type)
-	require.Equal(t, payload, sent.Payload)
+	expected := openapi.Notification{
+		Name:    name,
+		Event:   event.String(),
+		Type:    payloadType.String(),
+		Payload: payload,
+	}
+	notifications := mockClient.SentNotifications
+	require.Contains(t, notifications, expected)
 }

--- a/test/acceptance/util_setup_test.go
+++ b/test/acceptance/util_setup_test.go
@@ -2,6 +2,7 @@ package acceptance
 
 import (
 	"context"
+	"github.com/Interhyp/metadata-service/api"
 	application2 "github.com/Interhyp/metadata-service/internal/acorn/application"
 	"github.com/Interhyp/metadata-service/internal/acorn/repository"
 	"github.com/Interhyp/metadata-service/internal/acorn/service"
@@ -114,7 +115,7 @@ func tstSetup(configPath string) error {
 	registry.Setup()
 
 	for identifier, _ := range notifierImpl.Clients {
-		notifierImpl.Clients[identifier] = &notifiermock.NotifierClientMock{}
+		notifierImpl.Clients[identifier] = &notifiermock.NotifierClientMock{SentNotifications: make([]openapi.Notification, 0)}
 	}
 
 	tstSetupHttpTestServer()

--- a/test/mock/notifiermock/notifierclientmock.go
+++ b/test/mock/notifiermock/notifierclientmock.go
@@ -6,7 +6,7 @@ import (
 )
 
 type NotifierClientMock struct {
-	SentNotification *openapi.Notification
+	SentNotifications []openapi.Notification
 }
 
 func (n *NotifierClientMock) Setup(clientIdentifier string, url string) error {
@@ -14,9 +14,9 @@ func (n *NotifierClientMock) Setup(clientIdentifier string, url string) error {
 }
 
 func (n *NotifierClientMock) Send(ctx context.Context, notification openapi.Notification) {
-	n.SentNotification = &notification
+	n.SentNotifications = append(n.SentNotifications, notification)
 }
 
 func (n *NotifierClientMock) Reset() {
-	n.SentNotification = nil
+	n.SentNotifications = make([]openapi.Notification, 0)
 }

--- a/test/resources/acceptance-expected/owner-patch.json
+++ b/test/resources/acceptance-expected/owner-patch.json
@@ -1,6 +1,6 @@
 {
   "commitHash": "6c8ac2c35791edf9979623c717a2430000000000",
-  "contact": "somebody@some-organisation.com",
+  "contact": "changed@some-organisation.com",
   "defaultJiraProject": "ISSUE",
   "jiraIssue": "ISSUE-2345",
   "productOwner": "kschlangenheldt",

--- a/test/resources/acceptance-expected/repository-patch.json
+++ b/test/resources/acceptance-expected/repository-patch.json
@@ -1,7 +1,7 @@
 {
   "commitHash": "6c8ac2c35791edf9979623c717a2430000000000",
   "jiraIssue": "ISSUE-2345",
-  "mainline": "master",
+  "mainline": "main",
   "owner": "some-owner",
   "timeStamp": "2022-11-06T18:14:10Z",
   "unittest": false,


### PR DESCRIPTION
# Description

My previous change implemented the notifications such that they are only sent for changes created via the controller (aka REST calls). All changes made directly to the repository did go unnoticed. 
This pr fixes this behaviour by sending notifications as part of the updater. Unfortunately, because of this a notification for a change will be sent from every running pod.

Fixes # (issue)

# Checklist

- [ ] I have read the [CONTRIBUTING.md](/CONTRIBUTING-template.md)
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no lint errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Only MIT licensed or MIT license compatible dependencies are used (e.g.: Apache2 or BSD)
- [ ] The code contains no credentials, personalized data or company secrets