### PR TITLE
feat(#194): use contexthelper for async context

### DIFF
--- a/internal/web/controller/webhookctl/webhookctl.go
+++ b/internal/web/controller/webhookctl/webhookctl.go
@@ -3,14 +3,13 @@ package webhookctl
 import (
 	"context"
 	"github.com/Interhyp/metadata-service/internal/acorn/service"
+	"github.com/StephanHCB/go-backend-service-common/web/util/contexthelper"
 	"net/http"
 
 	"github.com/Interhyp/metadata-service/internal/web/util"
 	aulogging "github.com/StephanHCB/go-autumn-logging"
 	librepo "github.com/StephanHCB/go-backend-service-common/acorns/repository"
-	"github.com/StephanHCB/go-backend-service-common/web/middleware/requestid"
 	"github.com/go-chi/chi/v5"
-	"github.com/rs/zerolog/log"
 )
 
 type Impl struct {
@@ -29,8 +28,9 @@ func (c *Impl) WireUp(_ context.Context, router chi.Router) {
 func (c *Impl) Webhook(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	routineCtx := copyRequestContext(ctx)
+	routineCtx, routineCtxCancel := contexthelper.AsyncCopyRequestContext(ctx, "webhookExternalRepoChange", "backgroundJob")
 	go func() {
+		defer routineCtxCancel()
 		err := c.Updater.PerformFullUpdateWithNotifications(routineCtx)
 		if err != nil {
 			aulogging.Logger.Ctx(routineCtx).Error().WithErr(err).Printf("webhook error")
@@ -38,16 +38,4 @@ func (c *Impl) Webhook(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	util.SuccessNoBody(ctx, w, r, http.StatusNoContent)
-}
-
-func copyRequestContext(ctx context.Context) context.Context {
-	ctxCopy := context.Background()
-	logger := log.Logger
-	requestID := ctx.Value(requestid.RequestIDKey)
-	if requestID != nil {
-		ctxCopy = context.WithValue(ctxCopy, requestid.RequestIDKey, requestID)
-		logger = logger.With().Str("trace.id", requestID.(string)).Logger()
-	}
-	ctxCopy = logger.WithContext(ctxCopy)
-	return ctxCopy
 }


### PR DESCRIPTION
# Description

- use the contexthelper methods in go-autumn-backend-service-common
- fix APM tracing integration along the way

Fixes #194 
