### PR TITLE
fix(#229): bump go version for release

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - run: go build
       - uses: go-semantic-release/action@v1
         with:


### PR DESCRIPTION
# Description

Now the go version in the release workflow is too old. Let's hope it works now.

Fixes #229 

# Checklist

- [x] I have read the [CONTRIBUTING.md](/CONTRIBUTING-template.md)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no lint errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] Only MIT licensed or MIT license compatible dependencies are used (e.g.: Apache2 or BSD)
- [x] The code contains no credentials, personalized data or company secrets