### PR TITLE
RELTEC-11853: added "data" as optional field to keys-datastructure

### DIFF
--- a/api/generated_apimodel.go
+++ b/api/generated_apimodel.go
@@ -6,10 +6,6 @@ import (
 	"time"
 )
 
-type _dummyTime struct {
-	Timestamp *time.Time
-}
-
 type ConditionReferenceDto struct {
 	// Reference of a branch.
 	RefMatcher string `yaml:"refMatcher" json:"refMatcher"`
@@ -130,8 +126,13 @@ type Quicklink struct {
 	Description *string `yaml:"description,omitempty" json:"description,omitempty"`
 }
 
+type QuicklinkAllOf struct {
+	Description *string `yaml:"description,omitempty" json:"description,omitempty"`
+}
+
 type RepositoryConfigurationAccessKeyDto struct {
-	Key        string  `yaml:"key" json:"key"`
+	Key        *string `yaml:"key,omitempty" json:"key,omitempty"`
+	Data       *string `yaml:"data,omitempty" json:"data,omitempty"`
 	Permission *string `yaml:"permission,omitempty" json:"permission,omitempty"`
 }
 

--- a/api/openapi-v3-spec.json
+++ b/api/openapi-v3-spec.json
@@ -3029,16 +3029,12 @@
         }
       },
       "RepositoryConfigurationAccessKeyDto": {
-        "required": [
-          "key"
-        ],
         "properties": {
           "key": {
-            "type": "string",
-            "enum": [
-              "DEPLOYMENT",
-              "QUMULO"
-            ]
+            "type": "string"
+          },
+          "data": {
+            "type": "string"
           },
           "permission": {
             "type": "string",

--- a/internal/service/repositories/repositories_test.go
+++ b/internal/service/repositories/repositories_test.go
@@ -33,7 +33,7 @@ func createRepositoryDto() openapi.RepositoryDto {
 		Configuration: &openapi.RepositoryConfigurationDto{
 			AccessKeys: []openapi.RepositoryConfigurationAccessKeyDto{
 				{
-					Key:        "KEY",
+					Key:        ptr("KEY"),
 					Permission: ptr("REPO_WRITE"),
 				},
 			},
@@ -111,7 +111,7 @@ func TestPatchRepository_ReplaceAll(t *testing.T) {
 		Configuration: &openapi.RepositoryConfigurationDto{
 			AccessKeys: []openapi.RepositoryConfigurationAccessKeyDto{
 				{
-					Key:        "DEPLOYMENT",
+					Key:        ptr("DEPLOYMENT"),
 					Permission: ptr("REPO_READ"),
 				},
 			},
@@ -147,7 +147,7 @@ func TestPatchRepository_ReplaceAll(t *testing.T) {
 		Configuration: &openapi.RepositoryConfigurationDto{
 			AccessKeys: []openapi.RepositoryConfigurationAccessKeyDto{
 				{
-					Key:        "DEPLOYMENT",
+					Key:        ptr("DEPLOYMENT"),
 					Permission: ptr("REPO_READ"),
 				},
 			},

--- a/test/acceptance/util_dtos_test.go
+++ b/test/acceptance/util_dtos_test.go
@@ -234,7 +234,7 @@ func tstRepository() openapi.RepositoryDto {
 		Configuration: &openapi.RepositoryConfigurationDto{
 			AccessKeys: []openapi.RepositoryConfigurationAccessKeyDto{
 				{
-					Key:        "KEY",
+					Key:        p("KEY"),
 					Permission: p("REPO_WRITE"),
 				},
 			},


### PR DESCRIPTION
make "key" field optional

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

# Checklist

- [ ] I have read the [CONTRIBUTING.md](/CONTRIBUTING-template.md)
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no lint errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Only MIT licensed or MIT license compatible dependencies are used (e.g.: Apache2 or BSD)
- [ ] The code contains no credentials, personalized data or company secrets