### PR TITLE
fix(#303): make receive hook failure lead to 400 not 500

### DIFF
--- a/api/openapi-v3-spec.json
+++ b/api/openapi-v3-spec.json
@@ -2032,8 +2032,9 @@
             "type": "object",
             "description": "Map of string (group name e.g. some-owner) of strings (list of usernames), one username for each group is required.",
             "example": {
-              "some-owner": {
-              }
+              "some-owner": [
+                "someotheruser"
+              ]
             },
             "additionalProperties": {
               "type": "array",

--- a/internal/acorn/errors/githookerror/error.go
+++ b/internal/acorn/errors/githookerror/error.go
@@ -1,0 +1,14 @@
+package githookerror
+
+import "strings"
+
+const hookError = "pre-receive hook declined"
+
+// Is checks that an error is a git hook error.
+//
+// These errors occur during push operations.
+//
+// Unfortunately, we have to decide this by the error message, as go-git just uses fmt.Errorf().
+func Is(err error) bool {
+	return err != nil && strings.Contains(err.Error(), hookError)
+}

--- a/internal/service/updater/owners.go
+++ b/internal/service/updater/owners.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"github.com/Interhyp/metadata-service/api"
+	"github.com/Interhyp/metadata-service/internal/acorn/errors/githookerror"
 	"github.com/Interhyp/metadata-service/internal/acorn/errors/nochangeserror"
 	"github.com/Interhyp/metadata-service/internal/acorn/repository"
 	"github.com/Interhyp/metadata-service/internal/repository/notifier"
@@ -21,6 +22,9 @@ func (s *Impl) WriteOwner(ctx context.Context, ownerAlias string, owner openapi.
 				// there were no actual changes, this is acceptable
 				result.JiraIssue = "" // cannot know
 				return nil
+			}
+			if githookerror.Is(err) {
+				return s.httpErrorFromHook(err, owner.JiraIssue)
 			}
 			return err
 		}
@@ -46,6 +50,9 @@ func (s *Impl) DeleteOwner(ctx context.Context, ownerAlias string, deletionInfo 
 			if nochangeserror.Is(err) {
 				// there were no actual changes, this is acceptable
 				return nil
+			}
+			if githookerror.Is(err) {
+				return s.httpErrorFromHook(err, deletionInfo.JiraIssue)
 			}
 			return err
 		}

--- a/internal/service/updater/services.go
+++ b/internal/service/updater/services.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"github.com/Interhyp/metadata-service/api"
+	"github.com/Interhyp/metadata-service/internal/acorn/errors/githookerror"
 	"github.com/Interhyp/metadata-service/internal/acorn/errors/nochangeserror"
 	"github.com/Interhyp/metadata-service/internal/acorn/repository"
 	"github.com/Interhyp/metadata-service/internal/repository/notifier"
@@ -23,6 +24,9 @@ func (s *Impl) WriteService(ctx context.Context, serviceName string, service ope
 					// there were no actual changes, this is acceptable
 					result.JiraIssue = "" // cannot know, could be multiple issues for the affected files
 					return nil
+				}
+				if githookerror.Is(err) {
+					return s.httpErrorFromHook(err, service.JiraIssue)
 				}
 				return err
 			}
@@ -45,6 +49,9 @@ func (s *Impl) WriteService(ctx context.Context, serviceName string, service ope
 					// there were no actual changes, this is acceptable
 					result.JiraIssue = "" // cannot know
 					return nil
+				}
+				if githookerror.Is(err) {
+					return s.httpErrorFromHook(err, service.JiraIssue)
 				}
 				return err
 			}
@@ -70,6 +77,9 @@ func (s *Impl) DeleteService(ctx context.Context, serviceName string, deletionIn
 			if nochangeserror.Is(err) {
 				// there were no actual changes, this is acceptable
 				return nil
+			}
+			if githookerror.Is(err) {
+				return s.httpErrorFromHook(err, deletionInfo.JiraIssue)
 			}
 			return err
 		}

--- a/internal/service/updater/updater.go
+++ b/internal/service/updater/updater.go
@@ -2,12 +2,14 @@ package updater
 
 import (
 	"context"
+	"fmt"
 	"github.com/Interhyp/metadata-service/api"
 	"github.com/Interhyp/metadata-service/internal/acorn/config"
 	"github.com/Interhyp/metadata-service/internal/acorn/repository"
 	"github.com/Interhyp/metadata-service/internal/acorn/service"
 	auzerolog "github.com/StephanHCB/go-autumn-logging-zerolog"
 	librepo "github.com/StephanHCB/go-backend-service-common/acorns/repository"
+	"github.com/StephanHCB/go-backend-service-common/api/apierrors"
 	"github.com/StephanHCB/go-backend-service-common/web/middleware/requestid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog/log"
@@ -267,4 +269,11 @@ func equalExceptCacheInfo[T openapi.ServiceDto | openapi.OwnerDto | openapi.Repo
 		return *cleaned
 	}
 	return reflect.DeepEqual(clean(&first), clean(&second))
+}
+
+func (s *Impl) httpErrorFromHook(err error, jiraIssue string) error {
+	return apierrors.NewBadRequestError("push.receive.hook.declined",
+		fmt.Sprintf("git hook declined the commit - most likely your JIRA issue (%s) does not exist, has wrong type, or wrong status", jiraIssue),
+		err,
+		s.Timestamp.Now())
 }

--- a/test/acceptance/ownerctl_acc_test.go
+++ b/test/acceptance/ownerctl_acc_test.go
@@ -255,6 +255,25 @@ func TestPOSTOwner_GitServerDown(t *testing.T) {
 	require.Equal(t, 0, len(metadataImpl.FilesCommitted))
 }
 
+func TestPOSTOwner_GitHookDeclined(t *testing.T) {
+	tstReset()
+
+	docs.Given("Given an authenticated admin user")
+	token := tstValidAdminToken()
+
+	docs.When("When they request the creation of a valid owner, but supply an invalid issue")
+	body := tstOwner()
+	body.JiraIssue = "INVALID-12345"
+	response, err := tstPerformPost("/rest/api/v1/owners/post-owner-receive-hook", token, &body)
+
+	docs.Then("Then the request fails and the error response is as expected")
+	tstAssert(t, response, err, http.StatusBadRequest, "receive-hook-declined.json")
+
+	docs.Then("And the local metadata repository clone has been reset to its original state")
+	require.Equal(t, 0, len(metadataImpl.FilesWritten))
+	require.Equal(t, 0, len(metadataImpl.FilesCommitted))
+}
+
 // update full owner
 
 func TestPUTOwner_Success(t *testing.T) {
@@ -488,6 +507,25 @@ func TestPUTOwner_GitServerDown(t *testing.T) {
 	require.Equal(t, 0, len(metadataImpl.FilesCommitted))
 }
 
+func TestPUTOwner_GitHookDeclined(t *testing.T) {
+	tstReset()
+
+	docs.Given("Given an authenticated admin user")
+	token := tstValidAdminToken()
+
+	docs.When("When they request an update of an owner, but supply an invalid issue")
+	body := tstOwner()
+	body.JiraIssue = "INVALID-12345"
+	response, err := tstPerformPut("/rest/api/v1/owners/some-owner", token, &body)
+
+	docs.Then("Then the request fails and the error response is as expected")
+	tstAssert(t, response, err, http.StatusBadRequest, "receive-hook-declined.json")
+
+	docs.Then("And the local metadata repository clone has been reset to its original state")
+	require.Equal(t, 0, len(metadataImpl.FilesWritten))
+	require.Equal(t, 0, len(metadataImpl.FilesCommitted))
+}
+
 // patch owner
 
 func TestPATCHOwner_Success(t *testing.T) {
@@ -703,6 +741,25 @@ func TestPATCHOwner_GitServerDown(t *testing.T) {
 	require.Equal(t, 0, len(metadataImpl.FilesCommitted))
 }
 
+func TestPATCHOwner_GitHookDeclined(t *testing.T) {
+	tstReset()
+
+	docs.Given("Given an authenticated admin user")
+	token := tstValidAdminToken()
+
+	docs.When("When they request a patch of an owner, but supply an invalid issue")
+	body := tstOwnerPatch()
+	body.JiraIssue = "INVALID-12345"
+	response, err := tstPerformPatch("/rest/api/v1/owners/some-owner", token, &body)
+
+	docs.Then("Then the request fails and the error response is as expected")
+	tstAssert(t, response, err, http.StatusBadRequest, "receive-hook-declined.json")
+
+	docs.Then("And the local metadata repository clone has been reset to its original state")
+	require.Equal(t, 0, len(metadataImpl.FilesWritten))
+	require.Equal(t, 0, len(metadataImpl.FilesCommitted))
+}
+
 // delete owner
 
 func TestDELETEOwner_Success(t *testing.T) {
@@ -863,6 +920,25 @@ func TestDELETEOwner_GitServerDown(t *testing.T) {
 
 	docs.Then("Then the request fails and the error response is as expected")
 	tstAssert(t, response, err, http.StatusBadGateway, "bad-gateway.json")
+
+	docs.Then("And the local metadata repository clone has been reset to its original state")
+	require.Equal(t, 0, len(metadataImpl.FilesWritten))
+	require.Equal(t, 0, len(metadataImpl.FilesCommitted))
+}
+
+func TestDELETEOwner_GitHookDeclined(t *testing.T) {
+	tstReset()
+
+	docs.Given("Given an authenticated admin user")
+	token := tstValidAdminToken()
+
+	docs.When("When they request to delete an owner, but supply an invalid issue")
+	body := tstDelete()
+	body.JiraIssue = "INVALID-12345"
+	response, err := tstPerformDelete("/rest/api/v1/owners/deleteme", token, &body)
+
+	docs.Then("Then the request fails and the error response is as expected")
+	tstAssert(t, response, err, http.StatusBadRequest, "receive-hook-declined.json")
 
 	docs.Then("And the local metadata repository clone has been reset to its original state")
 	require.Equal(t, 0, len(metadataImpl.FilesWritten))

--- a/test/acceptance/repositoryctl_acc_test.go
+++ b/test/acceptance/repositoryctl_acc_test.go
@@ -308,6 +308,25 @@ func TestPOSTRepository_GitServerDown(t *testing.T) {
 	require.Equal(t, 0, len(metadataImpl.FilesCommitted))
 }
 
+func TestPOSTRepository_GitHookDeclined(t *testing.T) {
+	tstReset()
+
+	docs.Given("Given an authenticated admin user")
+	token := tstValidAdminToken()
+
+	docs.When("When they request the creation of a valid repository, but supply an invalid issue")
+	body := tstRepository()
+	body.JiraIssue = "INVALID-12345"
+	response, err := tstPerformPost("/rest/api/v1/repositories/new-repository.api", token, &body)
+
+	docs.Then("Then the request fails and the error response is as expected")
+	tstAssert(t, response, err, http.StatusBadRequest, "receive-hook-declined.json")
+
+	docs.Then("And the local metadata repository clone has been reset to its original state")
+	require.Equal(t, 0, len(metadataImpl.FilesWritten))
+	require.Equal(t, 0, len(metadataImpl.FilesCommitted))
+}
+
 // update full repository
 
 func TestPUTRepository_Success(t *testing.T) {
@@ -536,6 +555,25 @@ func TestPUTRepository_GitServerDown(t *testing.T) {
 
 	docs.Then("Then the request fails and the error response is as expected")
 	tstAssert(t, response, err, http.StatusBadGateway, "bad-gateway.json")
+
+	docs.Then("And the local metadata repository clone has been reset to its original state")
+	require.Equal(t, 0, len(metadataImpl.FilesWritten))
+	require.Equal(t, 0, len(metadataImpl.FilesCommitted))
+}
+
+func TestPUTRepository_GitHookDeclined(t *testing.T) {
+	tstReset()
+
+	docs.Given("Given an authenticated admin user")
+	token := tstValidAdminToken()
+
+	docs.When("When they request an update of a repository, but supply an invalid issue")
+	body := tstRepository()
+	body.JiraIssue = "INVALID-12345"
+	response, err := tstPerformPut("/rest/api/v1/repositories/karma-wrapper.helm-chart", token, &body)
+
+	docs.Then("Then the request fails and the error response is as expected")
+	tstAssert(t, response, err, http.StatusBadRequest, "receive-hook-declined.json")
 
 	docs.Then("And the local metadata repository clone has been reset to its original state")
 	require.Equal(t, 0, len(metadataImpl.FilesWritten))
@@ -830,6 +868,25 @@ func TestPATCHRepository_GitServerDown(t *testing.T) {
 	require.Equal(t, 0, len(metadataImpl.FilesCommitted))
 }
 
+func TestPATCHRepository_GitHookDeclined(t *testing.T) {
+	tstReset()
+
+	docs.Given("Given an authenticated admin user")
+	token := tstValidAdminToken()
+
+	docs.When("When they attempt to patch a repository, but supply an invalid issue")
+	body := tstRepositoryPatch()
+	body.JiraIssue = "INVALID-12345"
+	response, err := tstPerformPatch("/rest/api/v1/repositories/karma-wrapper.helm-chart", token, &body)
+
+	docs.Then("Then the request fails and the error response is as expected")
+	tstAssert(t, response, err, http.StatusBadRequest, "receive-hook-declined.json")
+
+	docs.Then("And the local metadata repository clone has been reset to its original state")
+	require.Equal(t, 0, len(metadataImpl.FilesWritten))
+	require.Equal(t, 0, len(metadataImpl.FilesCommitted))
+}
+
 func TestPATCHRepository_ChangeOwner(t *testing.T) {
 	tstReset()
 
@@ -1026,6 +1083,25 @@ func TestDELETERepository_GitServerDown(t *testing.T) {
 
 	docs.Then("Then the request fails and the error response is as expected")
 	tstAssert(t, response, err, http.StatusBadGateway, "bad-gateway.json")
+
+	docs.Then("And the local metadata repository clone has been reset to its original state")
+	require.Equal(t, 0, len(metadataImpl.FilesWritten))
+	require.Equal(t, 0, len(metadataImpl.FilesCommitted))
+}
+
+func TestDELETERepository_GitHookDeclined(t *testing.T) {
+	tstReset()
+
+	docs.Given("Given an authenticated admin user")
+	token := tstValidAdminToken()
+
+	docs.When("When they request to delete a repository, but supply an invalid issue")
+	body := tstDelete()
+	body.JiraIssue = "INVALID-12345"
+	response, err := tstPerformDelete("/rest/api/v1/repositories/karma-wrapper.helm-chart", token, &body)
+
+	docs.Then("Then the request fails and the error response is as expected")
+	tstAssert(t, response, err, http.StatusBadRequest, "receive-hook-declined.json")
 
 	docs.Then("And the local metadata repository clone has been reset to its original state")
 	require.Equal(t, 0, len(metadataImpl.FilesWritten))

--- a/test/resources/acceptance-expected/receive-hook-declined.json
+++ b/test/resources/acceptance-expected/receive-hook-declined.json
@@ -1,0 +1,5 @@
+{
+  "details": "git hook declined the commit - most likely your JIRA issue (INVALID-12345) does not exist, has wrong type, or wrong status",
+  "message": "push.receive.hook.declined",
+  "timestamp": "2022-11-06T18:14:10Z"
+}

--- a/test/resources/acceptance-expected/service-original.json
+++ b/test/resources/acceptance-expected/service-original.json
@@ -1,0 +1,18 @@
+{
+  "alertTarget": "https://webhook.com/9asdflk29d4m39g",
+  "commitHash": "6c8ac2c35791edf9979623c717a243fc53400000",
+  "developmentOnly": false,
+  "jiraIssue": "ISSUE-0000",
+  "owner": "some-owner",
+  "quicklinks": [
+    {
+      "title": "Swagger UI",
+      "url": "/swagger-ui/index.html"
+    }
+  ],
+  "repositories": [
+    "some-service-backend.helm-deployment",
+    "some-service-backend.implementation"
+  ],
+  "timeStamp": "2022-11-06T18:14:10Z"
+}


### PR DESCRIPTION
# Description

Git receive hook declined errors (which mostly happen when supplying an invalid JIRA issue in the dto) now return status 400 instead of 500, and give a meaningful error message.

Fixes #303 
